### PR TITLE
various small contributions by Michele I8FUC  20220814

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+**unreleased**
+- Add settings support for ivanmarcus (https://github.com/eroyee/openwebrx_E) _E added feature: top bar pushbuttons hide/show (via setip "Top Bar Panels Toggle Buttons Display")
+- Add settings support for ivanmarcus _E added feature: black background  mode for top bar image
+- Add settings support for ivanmarcus _E added feature: timeseries ( time_tick diagram start side, reticule db spacing, time tick spacing per profile )
+- add per profile secondary_demod_fft_offset_db settings support to align colour mappings for main waterfall and secondary waterfall
+- Add timeseries scale values offset to allign with main and secondary waterfall colour schemes
+- Add new pseudo-demodulator "Spectrum" to allow flexible secondary spectrum use for deep waterfall analysis with step variable bandwidth ( 50 Khz to 2 Khz); this feature help to gain detailed view of small ranges of a wide waterfall ( i.e. 8-10 Mhz with RSP1x devices)
+- Add pseudo-session-timeout via main page index meta http-equiv 
+- Add psedudo-session-timeout setting support via section "Pseudo Session Timeout" (to set landing page and session timeout)
+- add support for direwolf detailed packets logging with history
+- Add support for Mode column in left_panel for digital modes
+- Add support from luarvique (https://github.com/luarvique/openwebrx) for display of bandwitch presently in use on top of waterfall
+- Add support from luarvique (https://github.com/luarvique/openwebrx) for Settings item to configure callsign lookup database for map display
+- Add few corrections to bands.json
 
 **1.2.0-dev_E**
 

--- a/bands.json
+++ b/bands.json
@@ -52,7 +52,7 @@
   },
   {
     "name": "60m",
-    "lower_bound": 5351500,
+    "lower_bound": 5280000,
     "upper_bound": 5366500,
     "frequencies": {
       "ft8": 5357000,
@@ -183,7 +183,7 @@
   },
   {
     "name": "4m",
-    "lower_bound": 70150000,
+    "lower_bound": 70050000,
     "upper_bound": 70200000,
     "frequencies": {
       "wspr": 70091000
@@ -225,7 +225,7 @@
   },
   {
     "name": "13cm",
-    "lower_bound": 2320000000,
+    "lower_bound": 2300000000,
     "upper_bound": 2450000000,
     "frequencies": {
       "q65": [2301065000, 2304065000, 2320065000]

--- a/htdocs/css/openwebrx-header.css
+++ b/htdocs/css/openwebrx-header.css
@@ -1,8 +1,7 @@
 .webrx-top-container {
     position: relative;
     z-index:1000;
-    background-color: #000; /* eroyee; black scheme */
-/*    background-image: url(../gfx/openwebrx-top-photo.jpg); eroyee; black scheme */
+    background-image: url(../gfx/openwebrx-top-photo.jpg);
     background-position-x: center;
     background-position-y: top;
     background-repeat: no-repeat;
@@ -11,6 +10,19 @@
     overflow: hidden;
 }
 
+.webrx-top-container-black {   // by I8FUC to support ivanmarcus black_mod
+    position: relative;
+    z-index:1000;
+    background-color: #000; /* eroyee; black scheme */
+    background-position-x: center;
+    background-position-y: top;
+    background-repeat: no-repeat;
+    background-size: cover;
+
+    overflow: hidden;
+}
+
+
 .openwebrx-description-container {
     transition-property: height, opacity;
     transition-duration: 1s;
@@ -18,14 +30,14 @@
     opacity: 0;
     height: 0px;
     margin-top: 0px;
-    /* originally, top-bar + description was 350px */
-    max-height: 283px;
+    /* originally, top-bar + description was 350px then 283 - back to 320  by I8FUC */
+    max-height: 320px;
     overflow: hidden;
 }
 
 .openwebrx-description-container.expanded {
     opacity: 1;
-    height: 238px; /* eroyee dropped from 283 to to 238px incase added to spectrum */
+    height: 283px; /* eroyee dropped from 283 to to 238px in case added to spectrum - back by I8FUC */
 }
 
 /* eroyee add for spectrum display */
@@ -39,8 +51,8 @@
 }
 
 .webrx-top-bar {
-/* eroyee; change height to 40px from 67px */
-    height:40px;
+/* eroyee; change height to 40px from 67px - moved  to 45 by I8FUC */
+    height:45px;
     background: rgba(128, 128, 128, 0.15);
     margin:0;
     padding:0;
@@ -66,8 +78,8 @@
 }
 
 .webrx-top-logo {
-    width: 261px;
-    padding: 12px;
+    width: 235px;  // original 261  by I8FUC to 235 
+    padding: 10px;  // original 12 - moved to 10 by I8FUC
     filter: drop-shadow(0 0 2.5px rgba(0, 0, 0, .9));
     /* overwritten by media queries */
     display: none;
@@ -77,8 +89,8 @@
     background-color: rgba(154, 154, 154, .5);
     margin: 7px;
 
-    width: 46px;
-    height: 46px;
+    width: 66px; 
+    height: 40px;    // original 46px - moved to 40  by I8FUC
     padding: 4px;
     border-radius: 8px;
     box-sizing: content-box;
@@ -113,7 +125,7 @@
 }
 
 .openwebrx-main-buttons .button {
-    display: block;
+  //  display: block;   // by I8FUC to support top bar menu buttons hiding ; will be enabled by javascript
     width: 55px;
     cursor:pointer;
 }

--- a/htdocs/css/openwebrx.css
+++ b/htdocs/css/openwebrx.css
@@ -968,7 +968,7 @@ img.openwebrx-mirror-img
     /*margin: -10px -10px 10px -10px;*/
     margin: -10px -10px 0px -10px;
     border-radius: 15px;
-    height: 150px;
+    height: 300px;
     background-color: #333;
     position: relative;
     overflow: hidden;
@@ -1456,6 +1456,7 @@ img.openwebrx-mirror-img
 #openwebrx-panel-digimodes[data-mode="fst4"]   #openwebrx-digimode-content-container,
 #openwebrx-panel-digimodes[data-mode="fst4w"]  #openwebrx-digimode-content-container,
 #openwebrx-panel-digimodes[data-mode="q65"]    #openwebrx-digimode-content-container,
+#openwebrx-panel-digimodes[data-mode="spectrum"]    #openwebrx-digimode-content-container,
 #openwebrx-panel-digimodes[data-mode="ft8"]    #openwebrx-digimode-select-channel,
 #openwebrx-panel-digimodes[data-mode="wspr"]   #openwebrx-digimode-select-channel,
 #openwebrx-panel-digimodes[data-mode="jt65"]   #openwebrx-digimode-select-channel,
@@ -1466,7 +1467,8 @@ img.openwebrx-mirror-img
 #openwebrx-panel-digimodes[data-mode="js8"]    #openwebrx-digimode-select-channel,
 #openwebrx-panel-digimodes[data-mode="fst4"]   #openwebrx-digimode-select-channel,
 #openwebrx-panel-digimodes[data-mode="fst4w"]  #openwebrx-digimode-select-channel,
-#openwebrx-panel-digimodes[data-mode="q65"]    #openwebrx-digimode-select-channel
+#openwebrx-panel-digimodes[data-mode="q65"]    #openwebrx-digimode-select-channel,
+#openwebrx-panel-digimodes[data-mode="spectrum"]   #openwebrx-digimode-select-channel
 {
     display: none;
 }
@@ -1484,6 +1486,12 @@ img.openwebrx-mirror-img
 #openwebrx-panel-digimodes[data-mode="q65"]    #openwebrx-digimode-canvas-container
 {
     height: 200px;
+    margin: -10px;
+}
+
+#openwebrx-panel-digimodes[data-mode="spectrum"]    #openwebrx-digimode-canvas-container
+{
+    height: 400px;
     margin: -10px;
 }
 

--- a/htdocs/include/header.include.html
+++ b/htdocs/include/header.include.html
@@ -1,20 +1,20 @@
-<div class="webrx-top-container">
-    <div class="webrx-top-bar">
-<!--        <a href="https://www.openwebrx.de/" target="_blank"><svg viewBox="0 0 591 100" class="webrx-top-logo"><title>Visit the OpenWebRX homepage</title><use xlink:href="${document_root}static/gfx/svg-defs.svg#top-logo"></use></svg></a>
+<!--  several changes to support top bar menu buttons hiding and black_mod by a -  by I8FUCdmin settings -->
+<div class=${black_mod} id=${black_mod}  >
+    <div id="top_bar_buttons" class="webrx-top-bar">
+       <a href="https://www.openwebrx.de/" target="_blank"><svg viewBox="0 0 591 100" class="webrx-top-logo"><title>Visit the OpenWebRX homepage</title><use xlink:href="${document_root}static/gfx/svg-defs.svg#top-logo"></use></svg></a>
         <img class="webrx-rx-avatar openwebrx-photo-trigger" src="${document_root}static/gfx/openwebrx-avatar.png" alt="Receiver avatar"/>
         <div class="webrx-rx-texts openwebrx-photo-trigger">
             <h1 class="webrx-rx-title">${receiver_name}</h1>
             <div class="webrx-rx-desc">${receiver_location} | Loc: ${locator}, ASL: ${receiver_asl} m</div>
         </div>
---> 
        
     <section class="openwebrx-main-buttons">
-            <div class="button" data-toggle-panel="openwebrx-panel-status"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-status"></use></svg><br/>Status</div>
-            <div class="button" data-toggle-panel="openwebrx-panel-log"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-log"></use></svg><br/>Log</div>
-            <div class="button" data-toggle-panel="openwebrx-panel-receiver"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-receiver"></use></svg><br/>Receiver</div>
-<!--            <a class="button" href="${document_root}map" target="openwebrx-map"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-map"></use></svg><br/>Map</a>
-            <a class="button" href="${document_root}settings" target="openwebrx-settings"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-settings"></use></svg><br/>Settings</a>
--->
+            <dev  class="button" id=${status_button}   data-toggle-panel="openwebrx-panel-status"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-status"></use></svg><br/>Status</dev>
+            <dev  class="button" id=${log_button}   data-toggle-panel="openwebrx-panel-log"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-log"></use></svg><br/>Log</dev>
+            <dev  class="button" id=${receiver_button}   data-toggle-panel="openwebrx-panel-receiver"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-receiver"></use></svg><br/>Receiver</dev>
+            <a    class="button" id=${map_button}   href="${document_root}map" target="openwebrx-map"  ><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-map"></use></svg><br/>Map</a> 
+            <a    class="button" id=${settings_button}   href="${document_root}settings" target="openwebrx-settings"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-settings"></use></svg><br/>Settings</a>
+
         </section>
     </div>
     <!--  eroyee for spectrum display -->

--- a/htdocs/include/header.include.html
+++ b/htdocs/include/header.include.html
@@ -16,10 +16,10 @@
   var page = path.split("/").pop();
 //  console.log( page );
   if ( page === ""){
-    document.getElementById("pstt").innerHTML = "page_name_is=" + page + "<meta http-equiv=\"refresh\" content=\"${pseudo_session_timeout}; url=${rx_usage_policy_page}\"> ";
+    document.getElementById("pstt").innerHTML =  "<meta http-equiv=\"refresh\" content=\"${pseudo_session_timeout}; url=${rx_usage_policy_page}\"> ";
     }
   else{
-     document.getElementById("pstt").innerHTML = "page_name_is=" + page ;
+     document.getElementById("pstt").innerHTML = "" ;
      };
 </script>
  

--- a/htdocs/include/header.include.html
+++ b/htdocs/include/header.include.html
@@ -10,7 +10,19 @@
        
     <section class="openwebrx-main-buttons">
       <!-- pseudo-session-timeout and rx use policy page display feature by I8FUC -->
-      <meta http-equiv="refresh" content="${pseudo_session_timeout}; url=${rx_usage_policy_page}">  
+<p id="pstt"></p>
+<script>
+  var path = window.location.pathname;
+  var page = path.split("/").pop();
+//  console.log( page );
+  if ( page === ""){
+    document.getElementById("pstt").innerHTML = "page_name_is=" + page + "<meta http-equiv=\"refresh\" content=\"${pseudo_session_timeout}; url=${rx_usage_policy_page}\"> ";
+    }
+  else{
+     document.getElementById("pstt").innerHTML = "page_name_is=" + page ;
+     };
+</script>
+ 
             <dev  class="button" id=${status_button}   data-toggle-panel="openwebrx-panel-status"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-status"></use></svg><br/>Status</dev>
             <dev  class="button" id=${log_button}   data-toggle-panel="openwebrx-panel-log"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-log"></use></svg><br/>Log</dev>
             <dev  class="button" id=${receiver_button}   data-toggle-panel="openwebrx-panel-receiver"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-receiver"></use></svg><br/>Receiver</dev>

--- a/htdocs/include/header.include.html
+++ b/htdocs/include/header.include.html
@@ -9,6 +9,8 @@
         </div>
        
     <section class="openwebrx-main-buttons">
+      <!-- pseudo-session-timeout and rx use policy page display feature by I8FUC -->
+      <meta http-equiv="refresh" content="${pseudo_session_timeout}; url=${rx_usage_policy_page}">  
             <dev  class="button" id=${status_button}   data-toggle-panel="openwebrx-panel-status"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-status"></use></svg><br/>Status</dev>
             <dev  class="button" id=${log_button}   data-toggle-panel="openwebrx-panel-log"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-log"></use></svg><br/>Log</dev>
             <dev  class="button" id=${receiver_button}   data-toggle-panel="openwebrx-panel-receiver"><svg viewBox="0 0 80 80"><use xlink:href="${document_root}static/gfx/svg-defs.svg#panel-receiver"></use></svg><br/>Receiver</dev>

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -80,6 +80,8 @@
                         <div class="openwebrx-panel openwebrx-message-panel" id="openwebrx-panel-js8-message" style="display:none; width: 619px;" data-panel-name="js8-message"></div>
                         <div class="openwebrx-panel openwebrx-message-panel" id="openwebrx-panel-packet-message" style="display: none; width: 619px;" data-panel-name="aprs-message"></div>
                         <div class="openwebrx-panel openwebrx-message-panel" id="openwebrx-panel-pocsag-message" style="display: none; width: 619px;" data-panel-name="pocsag-message"></div>
+                        <div class="openwebrx-panel openwebrx-message-panel" id="openwebrx-panel-spectrum-message" style="display: none; width: 619px;" data-panel-name="spectrum-message"></div>                        
+                        
                         <div class="openwebrx-panel openwebrx-meta-panel" id="openwebrx-panel-metadata-m17" style="display: none;" data-panel-name="metadata-m17">
                             <div class="openwebrx-meta-slot">
                                 <div class="openwebrx-meta-user-image">

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -79,9 +79,7 @@
                         <div class="openwebrx-panel openwebrx-message-panel" id="openwebrx-panel-wsjt-message" style="display: none; width: 619px;" data-panel-name="wsjt-message"></div>
                         <div class="openwebrx-panel openwebrx-message-panel" id="openwebrx-panel-js8-message" style="display:none; width: 619px;" data-panel-name="js8-message"></div>
                         <div class="openwebrx-panel openwebrx-message-panel" id="openwebrx-panel-packet-message" style="display: none; width: 619px;" data-panel-name="aprs-message"></div>
-                        <div class="openwebrx-panel openwebrx-message-panel" id="openwebrx-panel-pocsag-message" style="display: none; width: 619px;" data-panel-name="pocsag-message"></div>
-                        <div class="openwebrx-panel openwebrx-message-panel" id="openwebrx-panel-spectrum-message" style="display: none; width: 619px;" data-panel-name="spectrum-message"></div>                        
-                        
+                        <div class="openwebrx-panel openwebrx-message-panel" id="openwebrx-panel-pocsag-message" style="display: none; width: 619px;" data-panel-name="pocsag-message"></div>                        
                         <div class="openwebrx-panel openwebrx-meta-panel" id="openwebrx-panel-metadata-m17" style="display: none;" data-panel-name="metadata-m17">
                             <div class="openwebrx-meta-slot">
                                 <div class="openwebrx-meta-user-image">

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -31,6 +31,7 @@
         <link rel="icon" type="image/png" sizes="96x96" href="static/gfx/favicon96.png" />
         <link rel="icon" type="image/png" sizes="128x128" href="static/gfx/favicon128.png" />
         <link rel="apple-touch-icon" href="apple-touch-icon.png">
+	<meta http-equiv="refresh" content="1800; url=http://meshtest.sarimesh.net/sdrrx.html">
         <meta name="msapplication-TileImage" content="mstile-144x144.png">
         <script src="compiled/receiver.js"></script>
         <link rel="stylesheet" type="text/css" href="static/lib/nanoscroller.css" />

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -31,7 +31,6 @@
         <link rel="icon" type="image/png" sizes="96x96" href="static/gfx/favicon96.png" />
         <link rel="icon" type="image/png" sizes="128x128" href="static/gfx/favicon128.png" />
         <link rel="apple-touch-icon" href="apple-touch-icon.png">
-	<meta http-equiv="refresh" content="1800; url=http://meshtest.sarimesh.net/sdrrx.html">
         <meta name="msapplication-TileImage" content="mstile-144x144.png">
         <script src="compiled/receiver.js"></script>
         <link rel="stylesheet" type="text/css" href="static/lib/nanoscroller.css" />

--- a/htdocs/lib/Demodulator.js
+++ b/htdocs/lib/Demodulator.js
@@ -13,6 +13,8 @@ Filter.prototype.getLimits = function() {
         max_bw = 100000;
     } else if (this.demodulator.get_modulation() === 'drm') {
         max_bw = 50000;
+    } else if (this.demodulator.get_modulation() === 'spectrum') {
+        max_bw = 50000;
     } else if (this.demodulator.get_modulation() === "freedv") {
         max_bw = 4000;
     } else {
@@ -81,6 +83,14 @@ Envelope.prototype.draw = function(visible_range){
         scale_ctx.fill();
         scale_ctx.globalAlpha = 1;
         scale_ctx.stroke();
+        // start by I8FUC 20220813
+        scale_ctx.lineWidth = 1;
+        scale_ctx.textAlign = "left";
+        scale_ctx.fillText(this.demodulator.high_cut.toString(), to_px + env_att_w, env_h2);
+        scale_ctx.textAlign = "right";
+        scale_ctx.fillText(this.demodulator.low_cut.toString(), from_px - env_att_w, env_h2);
+        scale_ctx.lineWidth = 3;
+        // end by I8FUC    
     }
     if (typeof line !== "undefined") // out of screen?
     {

--- a/htdocs/lib/Header.js
+++ b/htdocs/lib/Header.js
@@ -1,14 +1,23 @@
 function Header(el) {
     this.el = el;
-
+    var is_firefox = navigator.userAgent.indexOf("Firefox") ;  // by I8FUC 
+    
     var $buttons = this.el.find('.openwebrx-main-buttons').find('[data-toggle-panel]').filter(function(){
         // ignore buttons when the corresponding panel is not in the DOM
         return $('#' + $(this).data('toggle-panel'))[0];
     });
 
-    $buttons.css({display: 'block'}).click(function () {
+
+    if (navigator.userAgent.indexOf("Firefox") >= 0){  // by I8FUC to support correct top bar buttons hiding on firefox derived browsers
+      $buttons.css({display: 'block'}).click(function () {    
         toggle_panel($(this).data('toggle-panel'));
-    });
+        });
+      }
+    else{
+      $buttons.click(function () {    
+        toggle_panel($(this).data('toggle-panel'));
+        });    
+      };    
 
     this.init_rx_photo();
 };
@@ -30,6 +39,7 @@ Header.prototype.init_rx_photo = function() {
     });
 
     $('.webrx-top-container').find('.openwebrx-photo-trigger').click(this.toggle_rx_photo.bind(this));
+    $('.webrx-top-container-black').find('.openwebrx-photo-trigger').click(this.toggle_rx_photo.bind(this));  // by I8FUC to support ivanmarcus black_mod   
 };
 
 Header.prototype.close_rx_photo = function() {
@@ -64,4 +74,5 @@ $.fn.header = function() {
 
 $(function(){
     $('.webrx-top-container').header();
+    $('.webrx-top-container-black').header();  // by I8FUC to support ivanmarcus black_mod
 });

--- a/htdocs/lib/MessagePanel.js
+++ b/htdocs/lib/MessagePanel.js
@@ -65,6 +65,7 @@ WsjtMessagePanel.prototype.render = function() {
     $(this.el).append($(
         '<table>' +
             '<thead><tr>' +
+                '<th size=4 >Mode</th>' +
                 '<th>UTC</th>' +
                 '<th class="decimal">dB</th>' +
                 '<th class="decimal">DT</th>' +
@@ -106,6 +107,7 @@ WsjtMessagePanel.prototype.pushMessage = function(msg) {
     }
     $b.append($(
         '<tr data-timestamp="' + msg['timestamp'] + '">' +
+        '<td size=4 >' + msg['mode'] + '</td>' +
         '<td>' + pad(t.getUTCHours()) + pad(t.getUTCMinutes()) + pad(t.getUTCSeconds()) + '</td>' +
         '<td class="decimal">' + msg['db'] + '</td>' +
         '<td class="decimal">' + msg['dt'] + '</td>' +
@@ -138,6 +140,7 @@ PacketMessagePanel.prototype.render = function() {
     $(this.el).append($(
         '<table>' +
             '<thead><tr>' +
+                '<th size=4 >Mode </th>' +
                 '<th>UTC</th>' +
                 '<th class="callsign">Callsign</th>' +
                 '<th class="coord">Coord</th>' +
@@ -209,6 +212,7 @@ PacketMessagePanel.prototype.pushMessage = function(msg) {
 
     $b.append($(
         '<tr>' +
+        '<td size=4 >' + msg['mode'] + '</td>' +
         '<td>' + timestamp + '</td>' +
         '<td class="callsign">' + source + '</td>' +
         '<td class="coord">' + link + '</td>' +

--- a/htdocs/map.html
+++ b/htdocs/map.html
@@ -13,7 +13,6 @@
 </head>
 <body>
     ${header}
-    <meta http-equiv="refresh" content="86400; url=/map">     
     <div class="openwebrx-map"></div>
     <div class="openwebrx-map-legend">
         <h3>Colors</h3>

--- a/htdocs/map.html
+++ b/htdocs/map.html
@@ -13,6 +13,7 @@
 </head>
 <body>
     ${header}
+    <meta http-equiv="refresh" content="86400; url=/map">     
     <div class="openwebrx-map"></div>
     <div class="openwebrx-map-legend">
         <h3>Colors</h3>
@@ -22,5 +23,6 @@
         </select>
         <div class="content"></div>
     </div>
+
 </body>
 </html>

--- a/htdocs/map.js
+++ b/htdocs/map.js
@@ -37,6 +37,7 @@ $(function(){
     var retention_time = 2 * 60 * 60 * 1000;
     var strokeOpacity = 0.8;
     var fillOpacity = 0.35;
+    var callsign_url = null;
 
     var colorKeys = {};
     var colorScale = chroma.scale(['red', 'blue', 'green']).mode('hsl');
@@ -286,6 +287,9 @@ $(function(){
                         if ('map_position_retention_time' in config) {
                             retention_time = config.map_position_retention_time * 1000;
                         }
+                        if ('callsign_url' in config) {
+                            callsign_url = config['callsign_url'];
+                        }
                     break;
                     case "update":
                         processUpdates(json.value);
@@ -340,6 +344,17 @@ $(function(){
         return infowindow;
     }
 
+    var linkifyCallsign = function(callsign) {
+        if ((callsign_url == null) || (callsign_url == ''))
+            return callsign;
+        else
+            var arr = callsign.split('-');
+            var base_callsign = arr[0] ;
+            return '<a href="#" onclick="window.open(' + "'" +
+                callsign_url.replaceAll('{}', base_callsign) +
+                "','callsign_info'" + ');">' + base_callsign + '</a>';
+    };
+
     var infowindow;
     var showLocatorInfoWindow = function(locator, pos) {
         var infowindow = getInfoWindow();
@@ -357,7 +372,7 @@ $(function(){
             '<ul>' +
                 inLocator.map(function(i){
                     var timestring = moment(i.lastseen).fromNow();
-                    var message = i.callsign + ' (' + timestring + ' using ' + i.mode;
+                    var message = linkifyCallsign(i.callsign) + ' (' + timestring + ' using ' + i.mode;
                     if (i.band) message += ' on ' + i.band;
                     message += ')';
                     return '<li>' + message + '</li>'
@@ -378,7 +393,7 @@ $(function(){
             commentString = '<div>' + marker.comment + '</div>';
         }
         infowindow.setContent(
-            '<h3>' + callsign + '</h3>' +
+            '<h3>' + linkifyCallsign(callsign) + '</h3>' +
             '<div>' + timestring + ' using ' + marker.mode + ( marker.band ? ' on ' + marker.band : '' ) + '</div>' +
             commentString
         );

--- a/htdocs/map.js
+++ b/htdocs/map.js
@@ -37,8 +37,8 @@ $(function(){
     var retention_time = 2 * 60 * 60 * 1000;
     var strokeOpacity = 0.8;
     var fillOpacity = 0.35;
-    var callsign_url = null;
-
+    var callsign_url = null;   // by I8FUC 20220814
+ 
     var colorKeys = {};
     var colorScale = chroma.scale(['red', 'blue', 'green']).mode('hsl');
     var getColor = function(id){
@@ -287,7 +287,7 @@ $(function(){
                         if ('map_position_retention_time' in config) {
                             retention_time = config.map_position_retention_time * 1000;
                         }
-                        if ('callsign_url' in config) {
+                        if ('callsign_url' in config) {              //  // by I8FUC 20220814
                             callsign_url = config['callsign_url'];
                         }
                     break;
@@ -344,7 +344,7 @@ $(function(){
         return infowindow;
     }
 
-    var linkifyCallsign = function(callsign) {
+    var linkifyCallsign = function(callsign) {                      // by I8FUC 20220814
         if ((callsign_url == null) || (callsign_url == ''))
             return callsign;
         else
@@ -372,7 +372,7 @@ $(function(){
             '<ul>' +
                 inLocator.map(function(i){
                     var timestring = moment(i.lastseen).fromNow();
-                    var message = linkifyCallsign(i.callsign) + ' (' + timestring + ' using ' + i.mode;
+                    var message = linkifyCallsign(i.callsign) + ' (' + timestring + ' using ' + i.mode;   // by I8FUC 20220814
                     if (i.band) message += ' on ' + i.band;
                     message += ')';
                     return '<li>' + message + '</li>'
@@ -392,7 +392,7 @@ $(function(){
         if (marker.comment) {
             commentString = '<div>' + marker.comment + '</div>';
         }
-        infowindow.setContent(
+        infowindow.setContent(                            // by I8FUC 20220814
             '<h3>' + linkifyCallsign(callsign) + '</h3>' +
             '<div>' + timestring + ' using ' + marker.mode + ( marker.band ? ' on ' + marker.band : '' ) + '</div>' +
             commentString

--- a/htdocs/openwebrx.js
+++ b/htdocs/openwebrx.js
@@ -223,6 +223,7 @@ var waterfall_colors = buildWaterfallColors(['#000', '#FFF']);
 var waterfall_auto_levels;
 var waterfall_auto_min_range;
 
+
 function buildWaterfallColors(input) {
     return chroma.scale(input).colors(256, 'rgb');
 }
@@ -1706,7 +1707,7 @@ function waterfall_add(data) {
 //        let scaling = timeSeriesCtx.height/(Math.abs(waterfall_min_level)); // use for scale of 0dBm - wf_min_level
 //        const d = scaling * 10; // reticule line every 10dB of set window height // use for scale of 0dBm - wf_min_level
         let scaling = timeSeriesCtx.height / (Math.abs(waterfall_min_level - waterfall_max_level)); // scale from wf_min - wf_max
-        const d = (scaling * 10); // scale from wf_min - wf_max
+        const d = (scaling * 5); // scale from wf_min - wf_max ; changed by I8FUC from 10 to 5 20220721
         timeSeriesCtx.fillStyle = "#000";
         timeSeriesCtx.fillRect(0, 0, timeSeriesCtx.width, timeSeriesCtx.height);
         timeSeriesCtx.fillStyle = "#FFF";
@@ -1734,7 +1735,7 @@ function waterfall_add(data) {
 //---------------------------- reticule ----------------------------------------
         for (let i = 0; i < timeSeriesCtx.height; i++) {
             y = y + d; // reticule lines
-            dBnum = dBnum - 10;
+            dBnum = dBnum - 5;  //  changed by I8FUC from 10 to 5 2022072
             timeSeriesCtx.fillRect(0, y, timeSeriesCtx.width - (label_w), 0.5);  // draw lines
             timeSeriesCtx.fillText(dBnum + "dB", timeSeriesCtx.width - (label_w), y); // write -dB values @RHS
         }
@@ -1806,7 +1807,7 @@ function waterfall_add(data) {
 
 //--------------------------- reticule ----------------------------------------
         for (let i = 0; i < spectrumCtx.height; i++) {
-            dBnum = dBnum - 10; // label values
+            dBnum = dBnum - 5; // label values ; changed by I8FUC from 10 to 5 2022072
             y = y + d; // reticule lines
 //                spectrumCtx.fillStyle = "#FFF"; // white, comment out for colour coded lines
             screenCtx.fillStyle = spectrumGradient; // remove comment for coloured labelling
@@ -1927,6 +1928,7 @@ function openwebrx_init() {
     initSliders();
     /* ----- --eroyee add for keyboard tuning 28 Dec 20 --------------------- */
     init_key_listener();
+    initTopBarMenu() ;   // by I8FUC to support top bar ccomponents hiding by admin screens
     /* ---------------------------------------------------------------------- */
 }
 
@@ -2069,6 +2071,28 @@ function initPanels() {
             first_show_panel(el);
         }
     });
+
+}    
+    
+function initTopBarMenu() {    // by I8FUC to support top bar ccomponents hiding by admin screens
+    $('#top_bar_buttons').find('.button').each(function () {
+        var el = this;
+          if(el.id && el.id === 'status_but_disable' ) { el.style.display= 'none' ; }   ;
+          if(el.id && el.id === 'status_but_enable' ) { el.style.display= 'block' ; }   ;
+          
+          if(el.id && el.id ===  'log_but_disable' ) { el.style.display= 'none' ; }  ;  
+           if(el.id && el.id === 'log_but_enable' ) { el.style.display= 'block' ; }  ;          
+                  
+          if(el.id && el.id === 'receiver_but_disable' ) { el.style.display= 'none' ; }  ; 
+          if(el.id && el.id === 'receiver_but_enable' ) { el.style.display= 'block' ; }  ;           
+            
+          if(el.id && el.id ===  'map_but_disable' ) { el.style.display= 'none' ; }  ;
+           if(el.id && el.id === 'map_but_enable' ) { el.style.display= 'block' ; }  ;         
+          
+          if(el.id && el.id === 'settings_but_disable' ) { el.style.display= 'none' ; } ;                          
+          if(el.id && el.id === 'settings_but_enable' ) { el.style.display= 'block' ; } ;             
+    });
+
 }
 
 /*

--- a/htdocs/openwebrx.js
+++ b/htdocs/openwebrx.js
@@ -33,10 +33,13 @@ var fft_codec;
 var waterfall_setup_done = 0;
 var secondary_fft_size;
 var StepHz = 5000        // tuxtiger: for 1 / 5 / 9 kHz stepchange
-var default_time_tick = 60;
+// start  by I8FUC 20220806
+var default_time_tick = 60;           
 var default_sec_fft_offset_db = 10 ;
 var ts_start = "rhs";
 var default_ret_step = 5 ; 
+// end  by I8FUC 20220814
+
 
 function updateVolume() {
     audioEngine.setVolume(parseFloat($("#openwebrx-panel-volume").val()) / 100);
@@ -986,6 +989,7 @@ function on_ws_recv(evt) {
                 switch (json.type) {
                     case "config":
                         var config = json['value'];
+                        // start by I8FUC 20220806
                         if ('default_time_tick' in config) {
                             default_time_tick = config['default_time_tick'];
                         }
@@ -997,7 +1001,8 @@ function on_ws_recv(evt) {
                         }
                         if ('default_sec_fft_offset_db' in config) {
                             default_sec_fft_offset_db = config['default_sec_fft_offset_db'];
-                        }                                                             
+                        }
+                        // end by I8FUC 20220806                                                    
                         if ('waterfall_colors' in config) {
                             waterfall_colors = buildWaterfallColors(config['waterfall_colors']);
                         }
@@ -1522,6 +1527,7 @@ var timeSeriesCtx;
 var timeseries_start = false;
 const timeseries_window_h = 130;
 
+// modified by I8FUC 20220814
 const timeseries_data = new Array(screen.availWidth-34);		// do we want to start at the RHS?
 const timeseries_ticks = new Array(screen.availWidth-34).fill(0); 	// Follows from RHS      
  
@@ -1535,7 +1541,7 @@ function display_timeseries(status)
         display_spectra('stop');
     }
     if ((!timeseries_start) && (status = 'start')) {
-       if ( ts_start === "lhs"){
+       if ( ts_start === "lhs"){   // by I8FUC 20220812
           timeseries_data.length = 0;
           timeseries_ticks.length = 0;          
           };
@@ -1570,8 +1576,8 @@ function display_timeseries(status)
             const flush = document.querySelector("#signal-canvas-timeseries");
             flush.parentNode.removeChild(flush);
             timeseries_start = false;
-          //  timeseries_data.length = 0;
-          //  timeseries_ticks.length = 0;
+          //  timeseries_data.length = 0;   // removed by I8FUC
+          //  timeseries_ticks.length = 0;  // removed by I8FUC
             ts_out_data.length = 0;
             return;
         }
@@ -1745,7 +1751,7 @@ function waterfall_add(data) {
                 timeseries_ticks.push(date.getHours() + ":" + (mins = mins <= 9 ? '0' + mins : mins) + ":" + (secs = secs <= 9 ? '0' + secs : secs)); // gives leading 0's
             }
         }
-        var dBnum = Math.round(waterfall_max_level +10 ); // scale from wf_min - wf_max
+        var dBnum = Math.round(waterfall_max_level +10 ); // scale from wf_min - wf_max  - fix by I8FUC to adjut timeline y scale to waterfall colors
         if (timeseries_data.length >= timeSeriesCtx.width - (label_w)) { // subtract to stop trace & RHS text interacting
             timeseries_data.shift();  // yes this is a slow op but it doesn't appear to badly affect... 
             if (ts_ticks) {
@@ -1774,7 +1780,7 @@ function waterfall_add(data) {
                     timeSeriesCtx.fillText(timeseries_ticks[i], i + 3, timeSeriesCtx.height - 2) // write time alongside line
                 }
             }
-            y = timeSeriesCtx.height - (((timeseries_data[i] - waterfall_min_level - 10 ) / wfmax_min) * timeSeriesCtx.height); // scale the data now so changes in min_waterfall+max_waterfall and reticule are reflected - added 10 by I8FUC 20220814
+            y = timeSeriesCtx.height - (((timeseries_data[i] - waterfall_min_level - 10 ) / wfmax_min) * timeSeriesCtx.height); // scale the data now so changes in min_waterfall+max_waterfall and reticule are reflected - added 10 by I8FUC 20220814 to allign timeseries with waterfall colors
 //            y = (timeseries_data[i]*scaling); // scale the data so changes in min_waterfall and reticule are reflected - use if scale is 0dBm - wf_min
             timeSeriesCtx.lineTo(i, y);
         }

--- a/htdocs/settings.html
+++ b/htdocs/settings.html
@@ -10,6 +10,7 @@
 </head>
 <body>
 ${header}
+   <meta http-equiv="refresh" content="86400; url=/settings">   
 <div class="container">
     <div class="row">
         <h1 class="col-12">Settings</h1>

--- a/owrx/aprs/direwolf.py
+++ b/owrx/aprs/direwolf.py
@@ -82,6 +82,8 @@ MODEM 1200
 
 KISSPORT {port}
 AGWPORT off
+LOGDIR /var/log/direwolf_aprs.log
+
         """.format(
             port=self.getPort(), callsign=pm["aprs_callsign"]
         )

--- a/owrx/aprs/module.py
+++ b/owrx/aprs/module.py
@@ -44,7 +44,7 @@ class DirewolfModule(AutoStartModule, DirewolfConfigSubscriber):
 
         # direwolf -c {direwolf_config} -r {audio_rate} -t 0 -q d -q h 1>&2
         self.process = Popen(
-            ["direwolf", "-c", self.direwolfConfigPath, "-r", "48000", "-t", "0", "-q", "d", "-q", "h"],
+            ["direwolf", "-c", self.direwolfConfigPath, "-r", "48000", "-t", "0", "-q", "d", "-q", "h", "-d", "ai" ],
             start_new_session=True,
             stdin=PIPE,
         )

--- a/owrx/config/defaults.py
+++ b/owrx/config/defaults.py
@@ -33,6 +33,9 @@ defaultConfig = PropertyLayer(
                         samp_rate=2400000,
                         start_freq=439275000,
                         start_mod="nfm",
+                        default_time_tick=30,
+                        ts_start = "rhs",
+			default_ret_step = 5,
                     ),
                     "2m": PropertyLayer(
                         name="2m",
@@ -41,6 +44,9 @@ defaultConfig = PropertyLayer(
                         samp_rate=2048000,
                         start_freq=145725000,
                         start_mod="nfm",
+                        default_time_tick=30,
+                        ts_start = "rhs",
+			default_ret_step = 5,                        
                     ),
                 }
             ),
@@ -173,4 +179,5 @@ defaultConfig = PropertyLayer(
     # pskreporter_antenna_information=None,
     wsprnet_enabled=False,
     wsprnet_callsign="N0CALL",
+    callsign_url="https://www.qrz.com/db/{}",   
 ).readonly()

--- a/owrx/connection.py
+++ b/owrx/connection.py
@@ -121,6 +121,10 @@ class OpenWebRxReceiverClient(OpenWebRxClient, SdrSourceEventClient):
         "start_freq",
         "center_freq",
         "initial_squelch_level",
+        "default_time_tick",
+        "default_sec_fft_offset_db",
+        "ts_start",
+        "default_ret_step",        
         "sdr_id",
         "profile_id",
         "squelch_auto_margin",
@@ -457,6 +461,7 @@ class MapConnection(OpenWebRxClient):
             "receiver_gps",
             "map_position_retention_time",
             "receiver_name",
+            "callsign_url",
         )
         filtered_config.wire(self.write_config)
 

--- a/owrx/controllers/settings/general.py
+++ b/owrx/controllers/settings/general.py
@@ -226,23 +226,7 @@ class GeneralSettingsController(SettingsFormController):
                     append="s",
                 ),
             ),
-            Section(
-                "Mods settings",
-                TextInput(
-                    "mod_header_compose",
-                    "Mod: Header Compose Content",
-                    infotext="Allows verbose Header for main page, check out "
-                    + '<a href="https://developers.google.com/maps/documentation/embed/get-api-key" target="_blank">'
-                    + "their documentation</a> on how to obtain one.",
-                ),
-                NumberInput(
-                    "mod_id",
-                    "Mod Identity",
-                    infotext="Mod identity ",
-                    append="s",
-                ),
-            ),           
-            
+                      
         ]
 
     def remove_existing_image(self, image_id):

--- a/owrx/controllers/settings/general.py
+++ b/owrx/controllers/settings/general.py
@@ -182,7 +182,7 @@ class GeneralSettingsController(SettingsFormController):
                     + "waterfall colors",
                 ),
             ),
-            Section(
+             Section(
                 "Compression",
                 DropdownInput(
                     "audio_compression",
@@ -225,6 +225,13 @@ class GeneralSettingsController(SettingsFormController):
                     infotext="Specifies how log markers / grids will remain visible on the map",
                     append="s",
                 ),
+                TextInput(
+                    "callsign_url",
+                    "Callsign database URL",
+                    infotext="Specifies callsign lookup URL, such as QRZ.COM "
+                    + "or QRZCQ.COM. Place curly brackers ({}) where callsign "
+                    + "is supposed to be.",
+                ),                   
             ),
             Section(
                 "Pseudo Session Timeout",

--- a/owrx/controllers/settings/general.py
+++ b/owrx/controllers/settings/general.py
@@ -238,7 +238,7 @@ class GeneralSettingsController(SettingsFormController):
                 NumberInput(
                     "pseudo_session_timeout",
                     "Pseudo Session Timeout",
-                    infotext="Timeout for a user sessionin seconds",
+                    infotext="Timeout for a user session in seconds",
                     append="secs",
                 ),
             ),                      

--- a/owrx/controllers/settings/general.py
+++ b/owrx/controllers/settings/general.py
@@ -75,7 +75,7 @@ class GeneralSettingsController(SettingsFormController):
                 ),                                
             ),
             Section(
-                "Top Bar Display Components (still under test....)",
+                "Top Bar Panels Toggle Buttons Display ",
                 DropdownInput(
                     "status_button",
                     "Status Panel Button Display",
@@ -226,7 +226,22 @@ class GeneralSettingsController(SettingsFormController):
                     append="s",
                 ),
             ),
-                      
+            Section(
+                "Pseudo Session Timeout",
+                TextInput(
+                    "rx_usage_policy_page",
+                    "RX Usage Policy Details",
+                    infotext="URL for a page describing Usage Policy Rules and Objectives of this Receiver "
+                    + '<a href="https://my-web-site-owx.info" target="_blank">'
+                    + "..like this...</a>",
+                ),
+                NumberInput(
+                    "pseudo_session_timeout",
+                    "Pseudo Session Timeout",
+                    infotext="Timeout for a user sessionin seconds",
+                    append="secs",
+                ),
+            ),                      
         ]
 
     def remove_existing_image(self, image_id):

--- a/owrx/controllers/settings/general.py
+++ b/owrx/controllers/settings/general.py
@@ -64,7 +64,64 @@ class GeneralSettingsController(SettingsFormController):
                     infotext="For performance reasons, images are cached. "
                     + "It can take a few hours until they appear on the site.",
                 ),
+                DropdownInput(
+                    "black_mod",
+                    "Black background",
+                    infotext="Replace background photo with solid black ",
+                    options=[
+                        Option("webrx-top-container-black", "Enable"),
+                        Option("webrx-top-container", "Disable"),
+                    ],
+                ),                                
             ),
+            Section(
+                "Top Bar Display Components (still under test....)",
+                DropdownInput(
+                    "status_button",
+                    "Status Panel Button Display",
+                    infotext="Enable display of Bottom left Status Panel toggle button ",
+                    options=[
+                        Option("status_but_enable", "Enable"),
+                        Option("status_but_disable", "Disable"),
+                    ],
+                ), 
+                DropdownInput(
+                    "log_button",
+                    "Log Panel Button Display",
+                    infotext="Enable display of Bottom left Log panel toggle button ",
+                    options=[
+                        Option("log_but_enable", "Enable"),
+                        Option("log_but_disable", "Disable"),
+                    ],
+                ),
+                DropdownInput(
+                    "receiver_button",
+                    "Receiver Panel Button Display",
+                    infotext="Enable display of Bottom right Receiver Panel toggle button ",
+                    options=[
+                        Option("receiver_but_enable", "Enable"),
+                        Option("receiver_but_disable", "Disable"),
+                    ],
+                ), 
+                DropdownInput(
+                    "map_button",
+                    "Map Page Button Display",
+                    infotext="Direct link to Receiver Map Page Display ",
+                    options=[
+                        Option("map_but_enable", "Enable"),
+                        Option("map_but_disable", "Disable"),
+                    ],
+                ),
+                DropdownInput(
+                    "settings_button",
+                    "Settings Page Button Display",
+                    infotext="Direct link to Receiver Settings Page Display ",
+                    options=[
+                        Option("settings_but_enable", "Enable"),
+                        Option("settings_but_disable", "Disable"),
+                    ],
+                ),                                                
+            ),            
             Section(
                 "Receiver limits",
                 NumberInput(
@@ -169,6 +226,23 @@ class GeneralSettingsController(SettingsFormController):
                     append="s",
                 ),
             ),
+            Section(
+                "Mods settings",
+                TextInput(
+                    "mod_header_compose",
+                    "Mod: Header Compose Content",
+                    infotext="Allows verbose Header for main page, check out "
+                    + '<a href="https://developers.google.com/maps/documentation/embed/get-api-key" target="_blank">'
+                    + "their documentation</a> on how to obtain one.",
+                ),
+                NumberInput(
+                    "mod_id",
+                    "Mod Identity",
+                    infotext="Mod identity ",
+                    append="s",
+                ),
+            ),           
+            
         ]
 
     def remove_existing_image(self, image_id):

--- a/owrx/details.py
+++ b/owrx/details.py
@@ -24,7 +24,9 @@ class ReceiverDetails(PropertyFilter):
                 "log_button",
                 "receiver_button",
                 "map_button",
-                "settings_button",                                                                                
+                "settings_button",
+                "rx_usage_policy_page",
+                "pseudo_session_timeout",                                                                              
             )
         )
 

--- a/owrx/details.py
+++ b/owrx/details.py
@@ -26,7 +26,10 @@ class ReceiverDetails(PropertyFilter):
                 "map_button",
                 "settings_button",
                 "rx_usage_policy_page",
-                "pseudo_session_timeout",                                                                              
+                "pseudo_session_timeout", 
+                "ts_start",
+                "default_time_tick",
+                "default_ret_step",                                                                             
             )
         )
 

--- a/owrx/details.py
+++ b/owrx/details.py
@@ -7,6 +7,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+ 
 class ReceiverDetails(PropertyFilter):
     def __init__(self):
         super().__init__(
@@ -18,6 +19,12 @@ class ReceiverDetails(PropertyFilter):
                 "receiver_gps",
                 "photo_title",
                 "photo_desc",
+                "black_mod",
+                "status_button",
+                "log_button",
+                "receiver_button",
+                "map_button",
+                "settings_button",                                                                                
             )
         )
 

--- a/owrx/dsp.py
+++ b/owrx/dsp.py
@@ -521,9 +521,28 @@ class DspManager(SdrSourceEventClient, ClientDemodulatorSecondaryDspEventClient)
         if isinstance(demod, BaseDemodulatorChain):
             return demod
         # TODO: move this to Modes
-        if demod == "nfm":
+        if demod == "sp50":
             from csdr.chain.analog import NFm
             return NFm(self.props["output_rate"])
+        if demod == "sp25":
+            from csdr.chain.analog import NFm
+            return NFm(self.props["output_rate"])
+        if demod == "sp15":
+            from csdr.chain.analog import NFm
+            return NFm(self.props["output_rate"])
+        if demod == "sp10":
+            from csdr.chain.analog import NFm
+            return NFm(self.props["output_rate"])            
+        if demod == "sp5":
+            from csdr.chain.analog import NFm
+            return NFm(self.props["output_rate"])
+        if demod == "sp2":
+            from csdr.chain.analog import NFm
+            return NFm(self.props["output_rate"])                 
+        if demod == "nfm":
+            from csdr.chain.analog import NFm
+            return NFm(self.props["output_rate"])            
+            
         elif demod == "wfm":
             from csdr.chain.analog import WFm
             return WFm(self.props["hd_output_rate"], self.props["wfm_deemphasis_tau"])
@@ -588,6 +607,9 @@ class DspManager(SdrSourceEventClient, ClientDemodulatorSecondaryDspEventClient)
         elif mod == "packet":
             from csdr.chain.digimodes import PacketDemodulator
             return PacketDemodulator()
+        elif mod == "spectrum":
+            from csdr.chain.digimodes import PacketDemodulator
+            return PacketDemodulator()            
         elif mod == "pocsag":
             from csdr.chain.digimodes import PocsagDemodulator
             return PocsagDemodulator()

--- a/owrx/modes.py
+++ b/owrx/modes.py
@@ -99,6 +99,12 @@ class Modes(object):
         AnalogMode("lsb", "LSB", bandpass=Bandpass(-3000, -300)),
         AnalogMode("usb", "USB", bandpass=Bandpass(300, 3000)),
         AnalogMode("cw", "CW", bandpass=Bandpass(700, 900)),
+        AnalogMode("sp50", "SP50", bandpass=Bandpass(-25000, 25000)),
+        AnalogMode("sp25", "SP25", bandpass=Bandpass(-12500, 12500)),
+        AnalogMode("sp15", "SP15", bandpass=Bandpass(-7500, 7500)), 
+        AnalogMode("sp10", "SP10", bandpass=Bandpass(-5000, 5000)),
+        AnalogMode("sp5", "SP5", bandpass=Bandpass(-2500, 2500)),
+        AnalogMode("sp2", "SP2", bandpass=Bandpass(-1000, 1000)),                    
         AnalogMode("dmr", "DMR", bandpass=Bandpass(-4000, 4000), requirements=["digital_voice_digiham"], squelch=False),
         AnalogMode(
             "dstar", "D-Star", bandpass=Bandpass(-3250, 3250), requirements=["digital_voice_digiham"], squelch=False
@@ -130,6 +136,14 @@ class Modes(object):
             service=True,
             squelch=False,
         ),
+        DigitalMode(
+            "spectrum",
+            "Spectrum",
+            underlying=["sp50","sp25","sp15","sp10","sp5","sp2","nfm", "usb", "lsb"],        
+            requirements=["packet"],
+            service=False,
+            squelch=False,
+        ),        
         DigitalMode(
             "pocsag",
             "Pocsag",

--- a/owrx/source/__init__.py
+++ b/owrx/source/__init__.py
@@ -12,8 +12,13 @@ from owrx.command import CommandMapper
 from owrx.socket import getAvailablePort
 from owrx.property import PropertyStack, PropertyLayer, PropertyFilter, PropertyCarousel, PropertyDeleted
 from owrx.property.filter import ByLambda
-from owrx.form.input import Input, TextInput, NumberInput, CheckboxInput, ModesInput, ExponentialInput
-from owrx.form.input.converter import OptionalConverter
+
+from owrx.form.input import Input, TextInput, NumberInput, CheckboxInput, ModesInput, ExponentialInput, DropdownInput, Option
+from owrx.form.input.converter import OptionalConverter, IntConverter
+
+#from owrx.form.input import Input, TextInput, NumberInput, CheckboxInput, ModesInput, ExponentialInput, Option
+#from owrx.form.input.converter import OptionalConverter
+
 from owrx.form.input.device import GainInput, SchedulerInput, WaterfallLevelsInput
 from owrx.form.input.validator import RequiredValidator
 from owrx.form.section import OptionalSection
@@ -565,6 +570,36 @@ class SdrDeviceDescription(object):
             ExponentialInput("samp_rate", "Sample rate", "S/s"),
             ExponentialInput("start_freq", "Initial frequency", "Hz"),
             ModesInput("start_mod", "Initial modulation"),
+            DropdownInput(
+                "ts_start",
+                "TimeSeries starting point",
+                infotext="From where to start timeseries diagram at beginning ",
+                options=[
+                    Option("rhs", "RightEndSide"),
+                    Option("lhs", "LeftEndSide"),
+                    ],
+            ),
+            DropdownInput(
+                "default_time_tick",
+                "Default Time Ticks ",
+                infotext="Default Delta for time ticks ",                
+                options=[Option(str(i), "{} secs".format(i)) for i in [60, 30, 20, 10, 5]],
+                converter=IntConverter(),
+            ),
+            DropdownInput(
+                "default_ret_step",
+                "Default Reticule db step",
+                infotext="Default level difference for reticule lines ",
+                options=[Option(str(i), "{} db".format(i)) for i in [5, 10, 20]],
+                converter=IntConverter(),
+            ),
+            DropdownInput(
+                "default_sec_fft_offset_db",
+                "Default Secondary fft offset db",
+                infotext="Default offset for secondary fft panel with reference to main waterfall in db ",
+                options=[Option(str(i), "{} db".format(i)) for i in [5, 10, 15, 20, 25 , 30, 35, 40]],
+                converter=IntConverter(),
+            ),                         
             NumberInput("initial_squelch_level", "Initial squelch level", append="dBFS"),
         ]
 
@@ -589,7 +624,7 @@ class SdrDeviceDescription(object):
         return keys
 
     def getProfileMandatoryKeys(self):
-        return ["name", "center_freq", "samp_rate", "start_freq", "start_mod"]
+        return ["name", "center_freq", "samp_rate", "start_freq", "start_mod","default_time_tick","default_ret_step","ts_start", "default_sec_fft_offset_db"]
 
     def getProfileOptionalKeys(self):
         return ["initial_squelch_level", "rf_gain", "lfo_offset", "waterfall_levels"]


### PR DESCRIPTION
Hi,
please take a look to a number of changes  just in case you want to integrate them ... following a short list of changes

**unreleased**
- Add settings support for ivanmarcus (https://github.com/eroyee/openwebrx_E) _E added feature: top bar pushbuttons hide/show (via setip "Top Bar Panels Toggle Buttons Display")
- Add settings support for ivanmarcus _E added feature: black background  mode for top bar image
- Add settings support for ivanmarcus _E added feature: timeseries ( time_tick diagram start side, reticule db spacing, time tick spacing per profile )
- add per profile secondary_demod_fft_offset_db settings support to align colour mappings for main waterfall and secondary waterfall
- Add timeseries scale values offset to allign with main and secondary waterfall colour schemes
- Add new pseudo-demodulator "Spectrum" to allow flexible secondary spectrum use for deep waterfall analysis with step variable bandwidth ( 50 Khz to 2 Khz); this feature help to gain detailed view of small ranges of a wide waterfall ( i.e. 8-10 Mhz with RSP1x devices)
- Add pseudo-session-timeout via main page index meta http-equiv 
- Add psedudo-session-timeout setting support via section "Pseudo Session Timeout" (to set landing page and session timeout)
- add support for direwolf detailed packets logging with history
- Add support for Mode column in left_panel for digital modes
- Add support from luarvique (https://github.com/luarvique/openwebrx) for display of bandwitch presently in use on top of waterfall
- Add support from luarvique (https://github.com/luarvique/openwebrx) for Settings item to configure callsign lookup database for map display
- Add few corrections to bands.json

Michele
